### PR TITLE
Add Python 3.12 in GitHub Workflows

### DIFF
--- a/.github/workflows/automatic-tests.yml
+++ b/.github/workflows/automatic-tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/automatic-tests.yml
+++ b/.github/workflows/automatic-tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/automatic-tests.yml
+++ b/.github/workflows/automatic-tests.yml
@@ -11,9 +11,9 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -31,7 +31,7 @@ jobs:
         run: |
           pytest --cov --cov-report=lcov
       - name: Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: coverage.lcov

--- a/.github/workflows/automatic-tests.yml
+++ b/.github/workflows/automatic-tests.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           pytest --cov --cov-report=lcov
       - name: Coveralls
-        uses: coverallsapp/github-action@2
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: coverage.lcov

--- a/package/setup.py
+++ b/package/setup.py
@@ -62,6 +62,9 @@ try:
 					 'Programming Language :: Python :: 3',
 					 'Topic :: Software Development :: Libraries :: Python Modules'],
 		platforms='All',
+		install_requires = [
+			"packaging"
+			]
 		)
 	
 finally:

--- a/package/setup.py
+++ b/package/setup.py
@@ -63,7 +63,7 @@ try:
 					 'Topic :: Software Development :: Libraries :: Python Modules'],
 		platforms='All',
 		install_requires = [
-			"packaging"
+			"packaging",
 			]
 		)
 	

--- a/package/yapsy/PluginManager.py
+++ b/package/yapsy/PluginManager.py
@@ -128,7 +128,7 @@ API
 
 import sys
 import os
-import importlib
+import importlib.util
 
 from yapsy import log
 from yapsy import NormalizePluginNameForModuleName


### PR DESCRIPTION
Adding Python 3.12 in GitHub Workflows for testing.
Update GitHub Actions versions due to deprecation warnings on the CI.

**Updates**: For standalone package release instead of a development package.

* Added dependency on packaging for Plugin Versioning.
* `importlib.util`: Fix No Attribute Error using Python documentation recommendation to import `importlib.util` for handling plugin module imports.

**Refer:** https://github.com/tibonihoo/yapsy/pull/20

