### PR TITLE
test: Fix for import errors on plugins when executing isolated tests

### DIFF
--- a/package/test/plugins/VersionedPlugin10.py
+++ b/package/test/plugins/VersionedPlugin10.py
@@ -5,7 +5,8 @@
 This is certainly the second simplest plugin ever.
 """
 
-from test_settings import TEST_MESSAGE
+import logging
+TEST_MESSAGE = logging.debug
 from yapsy.IPlugin import IPlugin
 
 class VersionedPlugin10(IPlugin):

--- a/package/test/plugins/VersionedPlugin11.py
+++ b/package/test/plugins/VersionedPlugin11.py
@@ -5,7 +5,8 @@
 This is certainly the second simplest plugin ever.
 """
 
-from test_settings import TEST_MESSAGE
+import logging
+TEST_MESSAGE = logging.debug
 from yapsy.IPlugin import IPlugin
 
 class VersionedPlugin11(IPlugin):

--- a/package/test/plugins/VersionedPlugin111.py
+++ b/package/test/plugins/VersionedPlugin111.py
@@ -5,7 +5,8 @@
 This is certainly the second simplest plugin ever.
 """
 
-from test_settings import TEST_MESSAGE
+import logging
+TEST_MESSAGE = logging.debug
 from yapsy.IPlugin import IPlugin
 
 class VersionedPlugin111(IPlugin):

--- a/package/test/plugins/VersionedPlugin12.py
+++ b/package/test/plugins/VersionedPlugin12.py
@@ -5,7 +5,8 @@
 This is certainly the second simplest plugin ever.
 """
 
-from test_settings import TEST_MESSAGE
+import logging
+TEST_MESSAGE = logging.debug
 from yapsy.IPlugin import IPlugin
 
 class VersionedPlugin12(IPlugin):

--- a/package/test/plugins/VersionedPlugin12a1.py
+++ b/package/test/plugins/VersionedPlugin12a1.py
@@ -5,7 +5,8 @@
 This is certainly the second simplest plugin ever.
 """
 
-from test_settings import TEST_MESSAGE
+import logging
+TEST_MESSAGE = logging.debug
 from yapsy.IPlugin import IPlugin
 
 class VersionedPlugin12a1(IPlugin):

--- a/package/test/test_PluginInfo.py
+++ b/package/test/test_PluginInfo.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8; tab-width: 4; indent-tabs-mode: t; python-indent: 4 -*-
 
-from . import test_settings
 from configparser import ConfigParser
 import unittest
 

--- a/package/test/test_PluginInfo.py
+++ b/package/test/test_PluginInfo.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8; tab-width: 4; indent-tabs-mode: t; python-indent: 4 -*-
 
-import test_settings
+from . import test_settings
 from configparser import ConfigParser
 import unittest
 

--- a/package/test/test_VersionedPlugin.py
+++ b/package/test/test_VersionedPlugin.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8; tab-width: 4; indent-tabs-mode: t; python-indent: 4 -*-
 
-from . import test_settings
 from .test_settings import TEST_MESSAGE
 import unittest
 import os 


### PR DESCRIPTION
* import test_settings for fails in certain pytest invocation when running locally
  * The failing scenario is when triggering to execute individual tests:
  ```sh
  pytest --rootdir=$PWD package/test/test_VersionedPlugin.py
  ```
* Replaced TEST_MESSAGE with logging.debug as per the implementation in test_settings.py

Snippet of the error when using the above mentioned pytest command:
```
ERROR    yapsy:PluginManager.py:518 Unable to import plugin: /home/ameya/plugins/yapsy/package/test/plugins/VersionedPlugin12a1
Traceback (most recent call last):
  File "/home/ameya/plugins/yapsy/package/yapsy/PluginManager.py", line 515, in loadPlugins
    candidate_module = PluginManager._importModule(plugin_module_name, candidate_filepath)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ameya/plugins/yapsy/package/yapsy/PluginManager.py", line 587, in _importModule
    spec.loader.exec_module(candidate_module)
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/home/ameya/plugins/yapsy/package/test/plugins/VersionedPlugin12a1.py", line 8, in <module>
    from test_settings import TEST_MESSAGE
ModuleNotFoundError: No module named 'test_settings
```

**Refer:**  https://github.com/tibonihoo/yapsy/pull/24